### PR TITLE
Fix card count comment

### DIFF
--- a/Whist/GameLogic/GameState.swift
+++ b/Whist/GameLogic/GameState.swift
@@ -179,7 +179,7 @@ class GameState: ObservableObject, Codable, @unchecked Sendable {
             errors.append("Round \(round) is out of valid range (0...12).")
         }
         
-        // 2. All 32 cards accounted for and no duplicates
+        // 2. All 36 cards accounted for and no duplicates
         var allCards = deck
         players.forEach { allCards.append(contentsOf: $0.hand) }
         players.forEach { allCards.append(contentsOf: $0.trickCards) }


### PR DESCRIPTION
## Summary
- clarify that the integrity check expects all **36** cards

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840b96a89dc832f8431d44c8f5dfff8